### PR TITLE
Rename module for compatibility with go install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ If the configuration file is not found, a minimal empty one will be created. **I
 
 Binaries can be found in the Releases section.
 
+### Building from source
+
+```
+go install github.com/wsw70/dly@latest
+```
+
 ## Usage
 
 ### Interactive

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module dly
+module github.com/wsw70/dly
 
 go 1.19
 


### PR DESCRIPTION
Current naming is not suite well with `go install` flow. 
<img width="967" alt="Screenshot 2023-01-15 at 11 15 45" src="https://user-images.githubusercontent.com/4927633/212535134-c00a8528-1210-4ce3-8fd5-2ead3aa3cda9.png">

After merge, for correct working of `latest` tag you should add a new version tag after merge. Otherwise `@master` should be used.